### PR TITLE
Update Haml to v5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "middleman", "~> 4.2"
 gem "middleman-minify-html", "~> 3.4"
 
 # Reference: https://github.com/middleman/middleman/issues/2087
-gem "haml", "~> 4.0"
+gem "haml", "~> 5.0", ">= 5.0.1"
 
 # https://middlemanapp.com/basics/blogging/
 # gem "middleman-blog", "~> 4.0", ">= 4.0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,8 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.1.0)
     ffi (1.9.18)
-    haml (4.0.7)
+    haml (5.0.1)
+      temple (>= 0.8.0)
       tilt
     haml_lint (0.26.0)
       haml (>= 4.0, < 5.1)
@@ -152,6 +153,7 @@ GEM
     servolux (0.13.0)
     slop (3.6.0)
     sysexits (1.2.0)
+    temple (0.8.0)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -168,7 +170,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara (~> 2.14)
-  haml (~> 4.0)
+  haml (~> 5.0, >= 5.0.1)
   haml_lint
   launchy (~> 2.4)
   middleman (~> 4.2)

--- a/config.rb
+++ b/config.rb
@@ -3,6 +3,9 @@ activate :directory_indexes
 set :relative_links, true
 set :haml, { format: :html5 }
 
+# Disable Haml warnings
+Haml::TempleEngine.disable_option_validator!
+
 page "/*.xml", layout: false
 page "/*.json", layout: false
 page "/*.txt", layout: false


### PR DESCRIPTION
It now appears there is a workaround for the excessive error output issue with Haml 5 and Middleman.

- middleman/middleman#2087 (comment)